### PR TITLE
Genre

### DIFF
--- a/app/assets/javascripts/admin/genres.coffee
+++ b/app/assets/javascripts/admin/genres.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/admin/genres.scss
+++ b/app/assets/stylesheets/admin/genres.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the admin::Genres controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/admin/genres_controller.rb
+++ b/app/controllers/admin/genres_controller.rb
@@ -1,0 +1,32 @@
+class Admin::GenresController < ApplicationController
+  def index
+     @genres = Genre.all
+     @genre = Genre.new
+  end
+  
+  def create
+    @genre = Genre.new(genre_params)
+    @genre.save
+    redirect_back(fallback_location: root_path)
+    
+  end
+  
+    
+  
+  def edit
+    @genre =  Genre.find(params[:id])
+  end
+
+  def update
+    @genre = Genre.find(params[:id])
+    @genre.update(genre_params)
+    redirect_to  admin_genres_path, success: '登録に成功しました'
+  end
+
+   private
+
+  def genre_params
+    params.require(:genre).permit(:name)
+  end
+  
+end

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -24,4 +24,7 @@ class Admin::SessionsController < Devise::SessionsController
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
   # end
+  def after_sign_in_path_for(resource) 
+    admin_items_path
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
   end
 
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:last_name, :first_name])
   end
 
 end

--- a/app/helpers/admin/genres_helper.rb
+++ b/app/helpers/admin/genres_helper.rb
@@ -1,0 +1,2 @@
+module Admin::GenresHelper
+end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -6,4 +6,6 @@ class Admin < ApplicationRecord
   
    has_many :customers
    has_many :items
+   has_many :genres
+
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,2 +1,3 @@
 class Genre < ApplicationRecord
+  belongs_to :admin
 end

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,0 +1,14 @@
+<div class="container px-5 px-sm-0">
+    <h1>ジャンル編集</h1>
+    <div class="row">
+    <%= form_with model:@genre, url:admin_genre_path, local:true do |f| %>
+      <div class="form-group">
+          <%= f.label :name %>
+          <%= f.text_field :name, class: 'form-control book_title' %>
+      </div>
+      <div class="form-group">
+        <%= f.submit '変更を保存', class: 'btn btn-success' %>
+      </div>
+      <% end %>
+   </div>
+ </div>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,0 +1,38 @@
+
+<div class="container px-5 px-sm-0">
+  <h2>ジャンル一覧・追加</h2>
+  <div class="row">
+   <%= @genre.name %>
+    
+  <%= form_with model:@genre, url: admin_genres_path, local:true do |f| %>
+      <div class="form-group">
+      <%= f.label :name %>
+      <%= f.text_field :name, class: 'form-control book_title' %>
+      </div>
+     <div class="form-group">
+    <%= f.submit class: 'btn btn-success' %>
+    </div>
+  <% end %>
+    
+
+    <table class='table table-hover table-inverse'>
+    <thead>
+      <tr>
+        <th>ジャンル</th>
+        <th></th>
+        <th></th>
+        <th colspan="3"></th>
+      </tr>
+    </thead>
+    <tbody>
+       <% @genres.each do |genre| %>
+        <tr>
+          <td><%= genre.name %></td>
+          <td><%= link_to '編集', edit_admin_genre_path(genre)  %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+
+  </div>
+</div>

--- a/app/views/admin/items/new.html.erb
+++ b/app/views/admin/items/new.html.erb
@@ -1,1 +1,0 @@
-adomin itemu new ipage

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,26 +1,33 @@
-<h2>Log in</h2>
+<div class='container'>
+  <div class='row'>
+    <div class="col-sm-12 col-md-8 col-lg-5 px-5 px-sm-0">
+      <h2>Log in</h2>
+      
+      <%= form_with model: @admin, url: admin_session_path, local: true do |f| %>
+        <div class="field">
+          <%= f.label :email %><br />
+          <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+        </div>
+      
+        <div class="field">
+          <%= f.label :password %><br />
+          <%= f.password_field :password, autocomplete: "current-password" %>
+        </div>
+      
+        <% if devise_mapping.rememberable? %>
+          <div class="field">
+            <%= f.check_box :remember_me %>
+            <%= f.label :remember_me %>
+          </div>
+        <% end %>
+      
+        <div class="actions">
+          <%= f.submit "Log in" ,class: 'btn btn-sm btn-primary'%>
+        </div>
+      <% end %>
+      
+      <%= render "admin/shared/links" %>
 
-<%= form_with model: @admin, url: admin_session_path, local: true do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+      </div>
     </div>
-  <% end %>
-
-  <div class="actions">
-    <%= f.submit "Log in" %>
   </div>
-<% end %>
-
-<%= render "admin/shared/links" %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -13,10 +13,10 @@
           <li><%= link_to ' カート',class: 'nav-link'%></li>
           <li><%= link_to ' ログアウト', destroy_customer_session_path, method: :delete,class: 'nav-link' %></li>
         <% elsif admin_signed_in? %>
-          <li><%= link_to ' 商品一覧',class: 'nav-link' %></li>
+          <li><%= link_to ' 商品一覧', admin_items_path,class: 'nav-link' %></li>
           <li><%= link_to ' 会員一覧', public_customers_path,class: 'fas nav-link' %></li>
           <li><%= link_to ' 注文履歴一覧',class: 'fas nav-link text-light' %></li>
-          <li><%= link_to ' ジャンル一覧',class: 'fas nav-link' %></li>
+          <li><%= link_to ' ジャンル一覧', admin_genres_path, class: 'fas nav-link' %></li>
           <li><%= link_to ' ログアウト', destroy_customer_session_path, method: :delete,class: 'nav-link' %></li>
         <% else %>
           <li><%= link_to ' About',home_about_path,class: 'nav-link' %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :customers,except: [:create, :new, :destroy]
 
-    resources :generes,except: [:new, :show, :destroy]
+    resources :genres,except: [:new, :show, :destroy]
 
     resources :items,except: [:destroy]
 

--- a/test/controllers/admin/genres_controller_test.rb
+++ b/test/controllers/admin/genres_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Admin::GenresControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
admin　サインイン→トップページへの移動
genre機能・ページの実装
route.rb
genere→genreに記述ミスを修正
admin,genreモデルの紐づけ
ヘッダー部分のi顧客側tem一覧、管理側のジャンル一覧のURLの追加

懸念点
竜也君サイドでurlのブッキングを発見
顧客サイドの編集画面がdevise生成のviewと重複
別件で恐らくサインアップ時の顧客登録画面にて現状、メールのみしか登録がされておいらずカラムが空になっている